### PR TITLE
fix: App crash when clicking on Navbar Link

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -18,7 +18,7 @@ const Navbar = () => {
   const scrollToSection = (key) => {
     const el = document.getElementById(key);
     if (el) el.scrollIntoView({ behavior: "smooth" });
-    setMenuOpen(close);
+    setMenuOpen(false);
   };
 
   const links = [


### PR DESCRIPTION
- Fixed bug due to improper var in setState